### PR TITLE
AbstractFeedforward for PIDFFController

### DIFF
--- a/src/main/java/frc/robot/utilities/AbstractFeedForward.java
+++ b/src/main/java/frc/robot/utilities/AbstractFeedForward.java
@@ -1,0 +1,61 @@
+package frc.robot.utilities;
+
+import edu.wpi.first.math.controller.ArmFeedforward;
+import edu.wpi.first.math.controller.ElevatorFeedforward;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
+
+public abstract class AbstractFeedForward {
+  public abstract double calculate(double position, double velocity);
+
+  public static class AbstractSimpleFeedForward extends AbstractFeedForward {
+    private final SimpleMotorFeedforward ff;
+
+    public AbstractSimpleFeedForward(SimpleMotorFeedforward feedforward) {
+      this.ff = feedforward;
+    }
+
+    @Override
+    public double calculate(double position, double velocity) {
+      return ff.calculate(velocity);
+    }
+  }
+
+  public static class AbstractArmFeedForward extends AbstractFeedForward {
+    private final ArmFeedforward ff;
+
+    public AbstractArmFeedForward(ArmFeedforward feedforward) {
+      this.ff = feedforward;
+    }
+
+    @Override
+    public double calculate(double position, double velocity) {
+      return ff.calculate(position, velocity);
+    }
+  }
+
+  public static class AbstractArmDegFeedForward extends AbstractFeedForward {
+    private final ArmFeedforwardDeg ff;
+
+    public AbstractArmDegFeedForward(ArmFeedforwardDeg feedforward) {
+      this.ff = feedforward;
+    }
+
+    @Override
+    public double calculate(double position, double velocity) {
+      return ff.calculate(position, velocity);
+    }
+  }
+
+  public static class AbstractElevatorFeedForward extends AbstractFeedForward {
+    private final ElevatorFeedforward ff;
+
+    public AbstractElevatorFeedForward(ElevatorFeedforward feedforward) {
+      this.ff = feedforward;
+    }
+
+    @Override
+    public double calculate(double position, double velocity) {
+      return ff.calculate(velocity);
+    }
+  }
+}

--- a/src/main/java/frc/robot/utilities/ArmFeedforwardDeg.java
+++ b/src/main/java/frc/robot/utilities/ArmFeedforwardDeg.java
@@ -1,0 +1,25 @@
+package frc.robot.utilities;
+
+import edu.wpi.first.math.controller.ArmFeedforward;
+
+public class ArmFeedforwardDeg extends ArmFeedforward {
+
+  private static final double DEG2RADD = Math.PI / 180.0;
+
+  public ArmFeedforwardDeg(double ks, double kg, double kv) {
+    super(ks, kg, kv);
+  }
+
+  public ArmFeedforwardDeg(double ks, double kg, double kv, double ka) {
+    super(ks, kg, kv, ka);
+  }
+
+  @Override
+  public double calculate(
+      double positionDegrees, double velocityDegreesPerSec, double accelDegreesPerSecSquared) {
+    return ks * Math.signum(velocityDegreesPerSec * DEG2RADD)
+        + kg * Math.cos(positionDegrees * DEG2RADD)
+        + kv * velocityDegreesPerSec * DEG2RADD
+        + ka * accelDegreesPerSecSquared * DEG2RADD;
+  }
+}

--- a/src/main/java/frc/robot/utilities/PIDFFController.java
+++ b/src/main/java/frc/robot/utilities/PIDFFController.java
@@ -1,15 +1,14 @@
 package frc.robot.utilities;
 
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 
 public class PIDFFController extends PIDController {
-  private SimpleMotorFeedforward feedforward;
+  private AbstractFeedForward feedforward;
 
   public PIDFFController(PIDFFGains gains) {
     super(gains.kP.get(), gains.kI.get(), gains.kD.get());
 
-    feedforward = gains.createWpilibFeedforward();
+    feedforward = gains.createAbstractFeedForward();
     setTolerance(gains.tolerance.get());
   }
 
@@ -21,6 +20,6 @@ public class PIDFFController extends PIDController {
 
   @Override
   public double calculate(double measurement) {
-    return super.calculate(measurement) + feedforward.calculate(getSetpoint());
+    return super.calculate(measurement) + feedforward.calculate(getSetpoint(), getVelocityError());
   }
 }

--- a/src/main/java/frc/robot/utilities/PIDFFGains.java
+++ b/src/main/java/frc/robot/utilities/PIDFFGains.java
@@ -8,6 +8,7 @@ import lombok.NonNull;
 
 public class PIDFFGains {
   public TunableNumber kP, kI, kD, kS, kV, kG, tolerance;
+  public FeedforwardType feedforwardType;
   public static Set<String> names = new HashSet<>();
 
   private PIDFFGains(PIDFFGainsBuilder builder) {
@@ -18,6 +19,7 @@ public class PIDFFGains {
     kS = new TunableNumber(key + "kS", builder.kS);
     kV = new TunableNumber(key + "kV", builder.kV);
     kG = new TunableNumber(key + "kG", builder.kG);
+    feedforwardType = builder.feedforwardType;
     tolerance = new TunableNumber(key + "tolerance", builder.tolerance);
   }
 
@@ -58,12 +60,30 @@ public class PIDFFGains {
     return new PIDController(kP.get(), kI.get(), kD.get());
   }
 
+  public AbstractFeedForward createAbstractFeedForward() {
+    switch (feedforwardType) {
+      case ARM:
+        return new AbstractFeedForward.AbstractArmFeedForward(createArmFeedforward());
+      case ARM_DEG:
+        return new AbstractFeedForward.AbstractArmDegFeedForward(createArmDegFeedforward());
+      case ELEVAOTR:
+        return new AbstractFeedForward.AbstractElevatorFeedForward(createElevatorFeedforward());
+      case SIMPLE:
+        return new AbstractFeedForward.AbstractSimpleFeedForward(createWpilibFeedforward());
+    }
+    return null;
+  }
+
   public SimpleMotorFeedforward createWpilibFeedforward() {
     return new SimpleMotorFeedforward(kS.get(), kV.get());
   }
 
   public ArmFeedforward createArmFeedforward() {
     return new ArmFeedforward(kS.get(), kG.get(), kV.get());
+  }
+
+  public ArmFeedforwardDeg createArmDegFeedforward() {
+    return new ArmFeedforwardDeg(kS.get(), kG.get(), kV.get());
   }
 
   public ElevatorFeedforward createElevatorFeedforward() {
@@ -83,9 +103,17 @@ public class PIDFFGains {
     return new PIDFFGainsBuilder(name);
   }
 
+  public static enum FeedforwardType {
+    SIMPLE,
+    ARM,
+    ARM_DEG,
+    ELEVAOTR
+  }
+
   public static class PIDFFGainsBuilder {
     private String name;
     private double kP = 0, kI = 0, kD = 0, kS = 0, kV = 0, kG = 0;
+    private FeedforwardType feedforwardType = FeedforwardType.SIMPLE;
 
     // we wind up overwriting wpilib's default tolerance, which is 0.05, so set the same default
     // here to keep the same functionality
@@ -122,6 +150,21 @@ public class PIDFFGains {
 
     public PIDFFGainsBuilder kG(double kG) {
       this.kG = kG;
+      return this;
+    }
+
+    public PIDFFGainsBuilder armFF() {
+      this.feedforwardType = FeedforwardType.ARM;
+      return this;
+    }
+
+    public PIDFFGainsBuilder armDegFF() {
+      this.feedforwardType = FeedforwardType.ARM_DEG;
+      return this;
+    }
+
+    public PIDFFGainsBuilder elevatorFF() {
+      this.feedforwardType = FeedforwardType.ELEVAOTR;
       return this;
     }
 


### PR DESCRIPTION
Allows `PIDFFController` to use any `AbstractFeedforward` for feedforward values. Adds an enum to `PIDFFGainsBuilder` which stores the type so that it can be automatically used.